### PR TITLE
make sure we close the resp body.

### DIFF
--- a/raven/raven.go
+++ b/raven/raven.go
@@ -160,13 +160,11 @@ func (client Client) send(packet []byte, timestamp time.Time) (err error) {
 
 		resp, err := client.httpClient.Do(req)
 
-		if resp != nil {
-			defer resp.Body.Close()
-		}
-
 		if err != nil {
 			return err
 		}
+
+		defer resp.Body.Close()
 
 		switch resp.StatusCode {
 		case 301:


### PR DESCRIPTION
This patch makes sure we close the response body, otherwise we'll have
many connections in CLOSE_WAIT state and there associated go routines.
