### PR TITLE
fix the trailing slash issue.

### DIFF
--- a/raven/raven.go
+++ b/raven/raven.go
@@ -142,8 +142,8 @@ func (client Client) CaptureMessagef(format string, a ...interface{}) (result st
 // sends a packet to the sentry server with a given timestamp
 func (client Client) send(packet []byte, timestamp time.Time) (response *http.Response, err error) {
 	apiURL := *client.URL
-	apiURL.Path = path.Join(apiURL.Path, "/api/"+client.Project+"/store/")
-	apiURL.User = nil
+	apiURL.Path = path.Join(apiURL.Path, "/api/"+client.Project+"/store")
+	apiURL.Path += "/"
 	location := apiURL.String()
 
 	// for loop to follow redirects


### PR DESCRIPTION
Someone from the getsentry contacted us and brought to our attention that the endpoint we're hitting is invalid and doesn't have a trailing slash. this pull request fix this problem.
