### PR TITLE
Fix format arguments in CaptureMessagef

### DIFF
--- a/raven/raven.go
+++ b/raven/raven.go
@@ -110,7 +110,7 @@ func (client Client) CaptureMessage(message ...string) (result string, err error
 // CaptureMessagef is similar to CaptureMessage except it is using Printf like parameters for
 // formatting the message
 func (client Client) CaptureMessagef(format string, a ...interface{}) (result string, err error) {
-	return client.CaptureMessage(fmt.Sprintf(format, a))
+	return client.CaptureMessage(fmt.Sprintf(format, a...))
 }
 
 // Sends the given event to the sentry servers after encoding it into a byte slice.


### PR DESCRIPTION
Hey,

`CaptureMessagef` doesn't seem to actually format the message; it appears to be due to not expanding the input arguments on the subsequent `Sprintf` call. This change appears to fix it.
