### PR TITLE
Added the Go default Proxy settings to transport

### DIFF
--- a/raven/raven.go
+++ b/raven/raven.go
@@ -107,7 +107,11 @@ func NewClient(dsn string) (client *Client, err error) {
 		}
 	}
 
-	transport := &transport{httpTransport: &http.Transport{Dial: timeoutDialer(httpConnectTimeout)}, timeout: httpReadWriteTimeout}
+	transport := &transport{
+		httpTransport: &http.Transport{
+			Dial:  timeoutDialer(httpConnectTimeout),
+			Proxy: http.ProxyFromEnvironment,
+		}, timeout: httpReadWriteTimeout}
 	httpClient := &http.Client{transport, check, nil}
 	return &Client{URL: u, PublicKey: publicKey, SecretKey: secretKey, httpClient: httpClient, Project: project}, nil
 }


### PR DESCRIPTION
Just a small thing. It now considers the HTTP_PROXY and NO_PROXY environment variables just like the default Transport.
