### PR TITLE
Project should be an integer

### DIFF
--- a/raven/raven.go
+++ b/raven/raven.go
@@ -41,13 +41,13 @@ type Client struct {
 	URL        *url.URL
 	PublicKey  string
 	SecretKey  string
-	Project    string
+	Project    int
 	httpClient *http.Client
 }
 
 type Event struct {
 	EventId   string `json:"event_id"`
-	Project   string `json:"project"`
+	Project   int    `json:"project"`
 	Message   string `json:"message"`
 	Timestamp string `json:"timestamp"`
 	Level     string `json:"level"`
@@ -78,7 +78,10 @@ func NewClient(dsn string) (client *Client, err error) {
 	}
 
 	basePath := path.Dir(u.Path)
-	project := path.Base(u.Path)
+	project, err := strconv.Atoi(path.Base(u.Path))
+	if err != nil {
+		return nil, err
+	}
 
 	if u.User == nil {
 		return nil, fmt.Errorf("the DSN must contain a public and secret key")
@@ -191,7 +194,7 @@ func (client Client) Capture(ev *Event) error {
 // sends a packet to the sentry server with a given timestamp
 func (client Client) send(packet []byte, timestamp time.Time) (err error) {
 	apiURL := *client.URL
-	apiURL.Path = path.Join(apiURL.Path, "/api/"+client.Project+"/store")
+	apiURL.Path = path.Join(apiURL.Path, "/api/"+strconv.Itoa(client.Project)+"/store")
 	apiURL.Path += "/"
 	location := apiURL.String()
 

--- a/raven/raven_test.go
+++ b/raven/raven_test.go
@@ -6,14 +6,15 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"path"
+	"strconv"
 	"testing"
 	"time"
 )
 
-func BuildSentryDSN(baseUrl, publicKey, secretKey, project, sentryPath string) string {
+func BuildSentryDSN(baseUrl, publicKey, secretKey string, project int, sentryPath string) string {
 	u, _ := url.Parse(baseUrl)
 	u.User = url.UserPassword(publicKey, secretKey)
-	u.Path = path.Join(sentryPath, project)
+	u.Path = path.Join(sentryPath, strconv.Itoa(project))
 	return u.String()
 }
 
@@ -26,7 +27,7 @@ func TestCaptureMessage(t *testing.T) {
 
 	publicKey := "abcd"
 	secretKey := "efgh"
-	project := "1"
+	project := 1
 	sentryPath := "/sentry/path"
 
 	// Build the client
@@ -69,7 +70,7 @@ func TestCapture(t *testing.T) {
 
 	publicKey := "abcd"
 	secretKey := "efgh"
-	project := "1"
+	project := 1
 	sentryPath := "/sentry/path"
 
 	// Build the client
@@ -88,7 +89,7 @@ func TestCapture(t *testing.T) {
 		if ev.EventId == "" {
 			t.Error("EventId must not be empty.")
 		}
-		if ev.Project == "" {
+		if ev.Project == 0 {
 			t.Error("Project must not be empty.")
 		}
 		if ev.Timestamp == "" {
@@ -123,7 +124,7 @@ func TestTimeout(t *testing.T) {
 
 	publicKey := "abcd"
 	secretKey := "efgh"
-	project := "1"
+	project := 1
 	sentryPath := "/sentry/path"
 
 	// Build the client


### PR DESCRIPTION
The `project` parameter should be an integer.

In my use case, this is causing me issues. Basically, I am writing a "proxy" for `raven` which forwards events from `raven-js` to Sentry. Since `raven-js` passes `project` as an integer, it must be declared as such to be decoded.
