### PR TITLE
Ignore runtime functions when generating stacktraces instead of terminating

### DIFF
--- a/raven/raven.go
+++ b/raven/raven.go
@@ -69,8 +69,8 @@ func generateStacktrace() Stacktrace {
 		}
 		f := runtime.FuncForPC(pc)
 		if strings.Contains(f.Name(), "runtime") {
-			// Stop when reaching runtime
-			break
+			// Skip runtime calls
+			continue
 		}
 		if strings.Contains(f.Name(), "raven.Client") {
 			// Skip internal calls


### PR DESCRIPTION
When capturing stacktraces from a rescued panic, it looks like two `runtime` functions show up. This was causing stack tracing to stop early.

Here's an example full trace (all skipping disabled)

```
/go/src/github.com/kisielk/raven-go/raven/raven.go 214 github.com/kisielk/raven-go/raven.Client.Capture
/go/src/github.com/kisielk/raven-go/raven/raven.go 176 github.com/kisielk/raven-go/raven.Client.CaptureMessage
/go/src/media/main.go 42 main.func·001
/usr/src/go/src/runtime/asm_amd64.s 401 runtime.call16
/usr/src/go/src/runtime/panic.go 387 runtime.gopanic
/go/src/media/main.go 54 main.handleHealth
/go/src/github.com/zenazn/goji/web/handler.go 25 github.com/zenazn/goji/web.handlerFuncWrap.ServeHTTPC
/go/src/github.com/zenazn/goji/web/router.go 119 github.com/zenazn/goji/web.(*router).route
/go/src/github.com/zenazn/goji/web/middleware.go 88 github.com/zenazn/goji/web.func·002
```
